### PR TITLE
style: Update Cache-Control header settings

### DIFF
--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -7,10 +7,10 @@ export async function handler(req: Request, ctx: MiddlewareHandlerContext) {
 
   headers.set("Access-Control-Allow-Origin", origin);
   headers.set("Access-Control-Allow-Credentials", "true");
-  headers.set("Cache-Control", "public, max-age=14400");
+  headers.set("Cache-Control", "public, max-age=3600");
   headers.set(
     "Access-Control-Allow-Headers",
-    "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With",
+    "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, accept, origin, Cache-Control, X-Requested-With",
   );
   headers.set(
     "Access-Control-Allow-Methods",

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -7,6 +7,7 @@ export async function handler(req: Request, ctx: MiddlewareHandlerContext) {
 
   headers.set("Access-Control-Allow-Origin", origin);
   headers.set("Access-Control-Allow-Credentials", "true");
+  headers.set("X-Content-Type-Options", "nosniff");
   headers.set("Cache-Control", "public, max-age=3600");
   headers.set(
     "Access-Control-Allow-Headers",


### PR DESCRIPTION
Updated the max-age value of the Cache-Control header from 14400 to 3600 and removed X-CSRF-Token and Authorization headers.